### PR TITLE
Update README.md - Add missing CMake dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Dependencies (Recommended: Ubuntu 22.04):
 * Proj: `sudo apt install libproj-dev`
 * Protobuf (Map Service): `sudo apt install libprotobuf-dev protobuf-compiler`
 * Curl (Map Service): `sudo apt install libcurl4-openssl-dev`
+* CMake Version 3.25.0 or higher (not standard for Ubuntu 22.04, needs to be installed from source)
 
 You should also create the underlay, which is the underlying workspace with ROS2 Tools available. It behaves similarly to a virtual environment and allows having multiple ROS2 versions installed on the system and use a specific one for each project. The underlay can be created automatically for every terminal session or manually at the beginning of a new session like this:
 ```bash

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ git submodule update --init --recursive
 
 Dependencies (Recommended: Ubuntu 22.04):
 * [ROS2 Humble](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html)
-* Python: `sudo apt install python`
-* Boost: `sudo apt install libboost-all-dev`
-* Proj: `sudo apt install libproj-dev`
-* Protobuf (Map Service): `sudo apt install libprotobuf-dev protobuf-compiler`
-* Curl (Map Service): `sudo apt install libcurl4-openssl-dev`
-* CMake Version 3.25.0 or higher (not standard for Ubuntu 22.04, needs to be installed from source)
+* Python ^3.10: `sudo apt install python`
+* Boost ^1.74: `sudo apt install libboost-all-dev`
+* Proj ^8.2 : `sudo apt install libproj-dev`
+* Protobuf ^3.12 (Map Service): `sudo apt install libprotobuf-dev protobuf-compiler`
+* Curl ^7.81 (Map Service): `sudo apt install libcurl4-openssl-dev`
+* CMake Version ^3.25: [Install via official Kitware repositories](https://apt.kitware.com/)
 
 You should also create the underlay, which is the underlying workspace with ROS2 Tools available. It behaves similarly to a virtual environment and allows having multiple ROS2 versions installed on the system and use a specific one for each project. The underlay can be created automatically for every terminal session or manually at the beginning of a new session like this:
 ```bash

--- a/src/dsd_rail_horizon/config/parameters.yaml
+++ b/src/dsd_rail_horizon/config/parameters.yaml
@@ -1,7 +1,3 @@
----
-# SPDX-FileCopyrightText: Copyright DB Netz AG
-# SPDX-License-Identifier: CC0-1.0
-
 rail_horizon_publisher:
     ros__parameters:
         rail_horizon_namespace: /rail_horizon/
@@ -30,8 +26,8 @@ rail_horizon_publisher:
         coupled_localization_topic: /coupled_localization
         coupled_localization_use_geoid: false
         spoof_gnss_position: true
-        gnss_position: [10.131524972366783, 53.498649583384044, 63.99] # Mittlerer Landweg
-        #gnss_position: [10.205911539920013, 53.490093170540035, 63.99] # Bergedorf
+        # gnss_position: [10.131524972366783, 53.498649583384044, 63.99] # Mittlerer Landweg
+        gnss_position: [10.205911539920013, 53.490093170540035, 63.99] # Bergedorf
         gnss_rotation: [0.0, 0.0, 0.0]
         gnss_swap_lat_lon: false
         map_roi: [9.991913, 53.477225, 10.237787, 53.567761] # map_roi - region of interest

--- a/src/dsd_rail_horizon/config/parameters.yaml
+++ b/src/dsd_rail_horizon/config/parameters.yaml
@@ -1,3 +1,7 @@
+---
+# SPDX-FileCopyrightText: Copyright DB Netz AG
+# SPDX-License-Identifier: CC0-1.0
+
 rail_horizon_publisher:
     ros__parameters:
         rail_horizon_namespace: /rail_horizon/
@@ -26,8 +30,8 @@ rail_horizon_publisher:
         coupled_localization_topic: /coupled_localization
         coupled_localization_use_geoid: false
         spoof_gnss_position: true
-        # gnss_position: [10.131524972366783, 53.498649583384044, 63.99] # Mittlerer Landweg
-        gnss_position: [10.205911539920013, 53.490093170540035, 63.99] # Bergedorf
+        gnss_position: [10.131524972366783, 53.498649583384044, 63.99] # Mittlerer Landweg
+        #gnss_position: [10.205911539920013, 53.490093170540035, 63.99] # Bergedorf
         gnss_rotation: [0.0, 0.0, 0.0]
         gnss_swap_lat_lon: false
         map_roi: [9.991913, 53.477225, 10.237787, 53.567761] # map_roi - region of interest


### PR DESCRIPTION
The CMake version shipped from Ubuntu 22.04 (as recommended) is not suitable for this project. As requested there is the need for CMake 3.25.0 or higher.